### PR TITLE
Use the FQCN when calling the parse_acm_secrets filter

### DIFF
--- a/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -38,7 +38,7 @@
 
 - name: Set cleaned_acm_secrets fect
   ansible.builtin.set_fact:
-    cleaned_acm_secrets: "{{ acm_secrets.resources | parse_acm_secrets }}"
+    cleaned_acm_secrets: "{{ acm_secrets.resources | rhvp.cluster_utils.parse_acm_secrets }}"
 
 - name: Merge the two dicts together
   ansible.builtin.set_fact:


### PR DESCRIPTION
Otherwise we get the following error:

    fatal: [localhost]: FAILED! => {"msg": "template error while
    templating string: Could not load \"parse_acm_secrets\":
    'parse_acm_secrets'. String: {{ acm_secrets.resources |
    parse_acm_secrets }}. Could not load \"parse_acm_secrets\":
    'parse_acm_secrets'"}
