### PR TITLE
Remove links with - in the name because the usage of dash is not supported by ansible

### DIFF
--- a/playbooks/auto-approve-installplans.yml
+++ b/playbooks/auto-approve-installplans.yml
@@ -1,1 +1,0 @@
-auto_approve_installplans.yml

--- a/playbooks/hello-world.yml
+++ b/playbooks/hello-world.yml
@@ -1,1 +1,0 @@
-hello_world.yml

--- a/playbooks/iib-ci.yml
+++ b/playbooks/iib-ci.yml
@@ -1,1 +1,0 @@
-iib_ci.yml

--- a/playbooks/write-token-kubeconfig.yml
+++ b/playbooks/write-token-kubeconfig.yml
@@ -1,1 +1,0 @@
-write_token_kubeconfig.yml


### PR DESCRIPTION
The dash - character is not valid for playbook names in collections.

https://docs.ansible.com/ansible/latest/collections_guide/collections_using_playbooks.html