### PR TITLE
Only call vault_load_parsed_secrets when we did parse secrets

### DIFF
--- a/roles/vault_utils/tasks/push_parsed_secrets.yaml
+++ b/roles/vault_utils/tasks/push_parsed_secrets.yaml
@@ -41,3 +41,6 @@
   vault_load_parsed_secrets:
     vault_policies: "{{ vault_policies }}"
     parsed_secrets: "{{ parsed_secrets }}"
+  when:
+    - parsed_secrets is defined
+    - parsed_secrets | length > 0


### PR DESCRIPTION
Currently with IE 2.0 where there are no predefined secrets we fail as
follows:

    ...snip...

    TASK [Parse secrets data]
    [WARNING]: No secrets found
    [WARNING]: No secrets were parsed
    ok: [localhost]

    TASK [Load secrets using designated role and tasks]

    TASK [Do pre-checks for Vault]

    ...snip...

    TASK [rhvp.cluster_utils.vault_utils : Load parsed secrets into cluster vault]
    fatal: [localhost]: FAILED! => {"changed": false, "msg": "Must pass parsed_secrets"}

Let's invoke the vault_load_parsed_secrets module only when we did
manage to parse some secrets.

Now correctly passes:

    ...snip...

    TASK [Parse secrets data]
    [WARNING]: No secrets found
    [WARNING]: No secrets were parsed
    ok: [localhost]

    TASK [Load secrets using designated role and tasks]

    TASK [Do pre-checks for Vault]

    ...snip...

    TASK [rhvp.cluster_utils.vault_utils : Make sure that the vault auth policy exists]
    ok: [localhost]

    PLAY RECAP
    localhost                  : ok=23   changed=2    unreachable=0
    failed=0    skipped=8    rescued=0    ignored=0:
