### PR TITLE
v1 from main update

### DIFF
--- a/roles/vault_utils/README.md
+++ b/roles/vault_utils/README.md
@@ -138,6 +138,7 @@ secrets:
       description: "Please specify the password for application ABC"
     - name: secretprompt2
       value: defaultvalue
+      # Prompt will always ask for the password even if value is set, in which case a simple enter press will confirm the default values
       onMissingValue: prompt
       description: "Please specify the API key for XYZ"
     - name: secretprompt3

--- a/roles/vault_utils/tasks/push_parsed_secrets.yaml
+++ b/roles/vault_utils/tasks/push_parsed_secrets.yaml
@@ -41,3 +41,6 @@
   vault_load_parsed_secrets:
     vault_policies: "{{ vault_policies }}"
     parsed_secrets: "{{ parsed_secrets }}"
+  when:
+    - parsed_secrets is defined
+    - parsed_secrets | length > 0


### PR DESCRIPTION
- **Add short clarification about prompt in the examples**
- **Only call vault_load_parsed_secrets when we did parse secrets**
