### PR TITLE
allow var hide_sensitive_output to disable no_log in debug environments

### DIFF
--- a/playbooks/display_secrets_info.yml
+++ b/playbooks/display_secrets_info.yml
@@ -18,7 +18,7 @@
         secrets_yaml: '{{ values_secrets_data | from_yaml }}'
 
     - name: Parse secrets data
-      no_log: '{{ override_no_log | default(true) }}'
+      no_log: '{{ hide_sensitive_output | default(true) }}'
       parse_secrets_info:
         values_secrets_plaintext: "{{ values_secrets_data }}"
         secrets_backing_store: "{{ secrets_backing_store }}"

--- a/playbooks/process_secrets.yml
+++ b/playbooks/process_secrets.yml
@@ -24,7 +24,7 @@
         secrets_yaml: '{{ values_secrets_data | from_yaml }}'
 
     - name: Parse secrets data
-      no_log: '{{ override_no_log | default(true) }}'
+      no_log: '{{ hide_sensitive_output | default(true) }}'
       parse_secrets_info:
         values_secrets_plaintext: "{{ values_secrets_data }}"
         secrets_backing_store: "{{ secrets_backing_store }}"

--- a/roles/find_vp_secrets/tasks/main.yml
+++ b/roles/find_vp_secrets/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Once V1 support is dropped we can remove the whole secret_template support
 - name: Set secret_template fact
-  no_log: "{{ override_no_log | default(true) }}"
+  no_log: "{{ hide_sensitive_output | default(true) }}"
   ansible.builtin.set_fact:
     secret_template: "{{ pattern_dir }}/values-secret.yaml.template"
 
@@ -37,7 +37,7 @@
   when: custom_env_values_secret | default('') | length == 0
 
 - name: Is found values secret file encrypted
-  no_log: "{{ override_no_log | default(true) }}"
+  no_log: "{{ hide_sensitive_output | default(true) }}"
   ansible.builtin.shell: |
     set -o pipefail
     head -1 "{{ found_file }}" | grep -q \$ANSIBLE_VAULT
@@ -53,7 +53,7 @@
     msg: "Using {{ (lookup('env', 'HOME') | length > 0) | ternary(found_file | regex_replace('^' + lookup('env', 'HOME'), '~'), found_file) }} to parse secrets"
 
 - name: Set encryption bool fact
-  no_log: "{{ override_no_log | default(true) }}"
+  no_log: "{{ hide_sensitive_output | default(true) }}"
   ansible.builtin.set_fact:
     is_encrypted: "{{ encrypted.rc == 0 | bool }}"
 
@@ -65,7 +65,7 @@
   register: vault_pass
 
 - name: Get decrypted content if {{ found_file }} was encrypted
-  no_log: "{{ override_no_log | default(true) }}"
+  no_log: "{{ hide_sensitive_output | default(true) }}"
   ansible.builtin.shell:
     ansible-vault view --vault-password-file <(cat <<<"{{ vault_pass.user_input }}") "{{ found_file }}"
   register: values_secret_plaintext
@@ -73,14 +73,14 @@
   changed_when: false
 
 - name: Normalize secrets format (un-encrypted)
-  no_log: '{{ override_no_log | default(true) }}'
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     values_secrets_data: "{{ lookup('file', found_file) | from_yaml }}"
   when: not is_encrypted
   changed_when: false
 
 - name: Normalize secrets format (encrypted)
-  no_log: '{{ override_no_log | default(true) }}'
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     values_secrets_data: "{{ values_secret_plaintext.stdout | from_yaml }}"
   when: is_encrypted

--- a/roles/k8s_secret_utils/tasks/inject_k8s_secret.yml
+++ b/roles/k8s_secret_utils/tasks/inject_k8s_secret.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check for secrets namespace
-  no_log: false
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_info:
     kind: Namespace
     name: "{{ item['metadata']['namespace'] }}"
@@ -10,6 +10,6 @@
   delay: 45
 
 - name: Inject k8s secret
-  no_log: '{{ override_no_log | default(True) }}'
+  no_log: '{{ hide_sensitive_output | default(True) }}'
   kubernetes.core.k8s:
     definition: '{{ item }}'

--- a/roles/k8s_secret_utils/tasks/inject_k8s_secrets.yml
+++ b/roles/k8s_secret_utils/tasks/inject_k8s_secrets.yml
@@ -1,5 +1,5 @@
 ---
 - name: Inject secrets
-  no_log: '{{ override_no_log | default(True) }}'
+  no_log: '{{ hide_sensitive_output | default(True) }}'
   ansible.builtin.include_tasks: inject_k8s_secret.yml
   loop: '{{ kubernetes_secret_objects }}'

--- a/roles/k8s_secret_utils/tasks/parse_secrets.yml
+++ b/roles/k8s_secret_utils/tasks/parse_secrets.yml
@@ -1,12 +1,12 @@
 ---
 - name: Parse secrets data
-  # no_log: '{{ override_no_log | default(true) }}'
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   parse_secrets_info:
     values_secrets_plaintext: "{{ values_secrets_data }}"
     secrets_backing_store: "{{ secrets_backing_store }}"
   register: secrets_results
 
 - name: Return kubernetes objects
-  no_log: '{{ override_no_log | default(true) }}'
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     kubernetes_secret_objects: "{{ secrets_results['kubernetes_secret_objects'] }}"

--- a/roles/vault_utils/tasks/push_secrets.yaml
+++ b/roles/vault_utils/tasks/push_secrets.yaml
@@ -37,7 +37,7 @@
 
 # Once V1 support is dropped we can remove the whole secret_template support
 - name: Set secret_template fact
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     secret_template: "{{ pattern_dir }}/values-secret.yaml.template"
 
@@ -73,7 +73,7 @@
   when: custom_env_values_secret | default('') | length == 0
 
 - name: Is found values secret file encrypted
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.shell: |
     set -o pipefail
     head -1 "{{ found_file }}" | grep -q \$ANSIBLE_VAULT
@@ -89,7 +89,7 @@
     msg: "Using {{ (lookup('env', 'HOME') | length > 0) | ternary(found_file | regex_replace('^' + lookup('env', 'HOME'), '~'), found_file) }} to parse secrets"
 
 - name: Set encryption bool fact
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     is_encrypted: "{{ encrypted.rc == 0 | bool }}"
 
@@ -101,7 +101,7 @@
   register: vault_pass
 
 - name: Get decrypted content if {{ found_file }} was encrypted
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.shell:
     ansible-vault view --vault-password-file <(cat <<<"{{ vault_pass.user_input }}") "{{ found_file }}"
   register: values_secret_plaintext
@@ -109,7 +109,7 @@
   changed_when: false
 
 - name: Loads secrets file into the vault of a cluster
-  no_log: false
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   vault_load_secrets:
     values_secrets: "{{ found_file }}"
     check_missing_secrets: false
@@ -117,7 +117,7 @@
   when: not is_encrypted
 
 - name: Loads secrets file into the vault of a cluster
-  no_log: false
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   vault_load_secrets:
     values_secrets_plaintext: "{{ values_secret_plaintext.stdout }}"
     check_missing_secrets: false

--- a/roles/vault_utils/tasks/vault_init.yaml
+++ b/roles/vault_utils/tasks/vault_init.yaml
@@ -10,7 +10,7 @@
 # We need to retry here because the vault service might be starting
 # and can return a 500 internal server until its state is fully ready
 - name: Init vault operator
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
@@ -22,7 +22,7 @@
   when: not vault_initialized
 
 - name: Set vault init output json fact
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     vault_init_json: "{{ vault_init_json_out.stdout | from_json }}"
   when: not vault_initialized
@@ -31,7 +31,7 @@
 # the cluster when the vault was not already initialized *and* when
 # unseal_from_cluster is set to true
 - name: Save vault operator output (into a secret inside the cluster)
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s:
     state: present
     definition:

--- a/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -32,7 +32,7 @@
   when: kubernetes_enabled.rc != 0
 
 - name: Get token from service account secret {{ external_secrets_ns }}/{{ external_secrets_secret }}
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
@@ -42,12 +42,12 @@
   failed_when: token_data.resources | length == 0
 
 - name: Set sa_token fact
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   ansible.builtin.set_fact:
     sa_token: "{{ token_data.resources[0].data.token | b64decode }}"
 
 - name: Configure hub kubernetes backend
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"

--- a/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -77,11 +77,11 @@
   # will leave the ['esoToken'] field empty in the dict which will make it so that
   # the spoke gets skipped
   ignore_errors: true
-  # We add no_log: true here because in case of a remote failure secret bits might
+  # We add no_log: '{{ hide_sensitive_output | default(true) }}' here because in case of a remote failure secret bits might
   # end up in the log. Unfortunately ansible is currently not easily able to control
   # output in a loop (see
   # https://serverfault.com/questions/1059530/how-to-not-print-items-in-an-ansible-loop-error-without-no-log)
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   when:
     - clusters_info[item.key]['bearerToken'] is defined
     - clusters_info[item.key]['server_api'] is defined
@@ -127,7 +127,7 @@
     label: "{{ item.key }}"
 
 - name: Is kubernetes backend already enabled
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
@@ -142,7 +142,7 @@
     label: "{{ item.key }}"
 
 - name: Configure kubernetes backend
-  no_log: true
+  no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"


### PR DESCRIPTION
Adds the var hide_sensitive_output eveywhere we have no_log so that sensitive data like secrets are hidden by default. Setting this var to `false` allows us temporarily disable the no_log protection when we are debugging in secure environments.

An example of how we can use this is to set
```sh
export EXTRA_PLAYBOOK_OPTS='-e hide_sensitive_output="false" -vvv'
```
before we run a command like `./pattern.sh make load-secrets`. (Do note, however, that we currently do not actually propagate this environment variable to the `ansible-playbook` command. A separate PR is required to update our common module to propagate this value to all of the playbooks.)

With that env var set the output looks like:
![image](https://github.com/user-attachments/assets/b93d7023-8602-477a-bfbd-906c965e9a7e)

Without setting that var the output looks like:
![image](https://github.com/user-attachments/assets/1be4c667-4338-4c84-b8e5-ff198ad04810)