### PR TITLE
MBP-787 double timeout to wait for iib catalog source to be ready

### DIFF
--- a/roles/iib_ci/tasks/install-iib-in-cluster.yml
+++ b/roles/iib_ci/tasks/install-iib-in-cluster.yml
@@ -50,7 +50,7 @@
     oc get -n "{{ internal_registry_ns }}" packagemanifests -l "catalog=iib-{{ item.value['iib'] }}" --field-selector "metadata.name={{ item.key }}" \
       -o jsonpath='{.items[0].status.defaultChannel}'
   register: oc_catalogsource_result
-  retries: 30
+  retries: 60
   delay: 10
   until: oc_catalogsource_result is not failed
   changed_when: false


### PR DESCRIPTION
Many times in our pre-release pipelines we fail waiting for iib
catalog sources to be ready despite the fact that we can see them
created in the must-gather logs within a minute of the failing timeout.
Hopefully, increasing the timeout by another 5 minutes resolves all
these failures.
