### PR TITLE
Adding the ability to pass environment variables to the k8s_exec call.

### DIFF
--- a/roles/vault_utils/defaults/main.yml
+++ b/roles/vault_utils/defaults/main.yml
@@ -24,3 +24,6 @@ external_secrets_sa: golang-external-secrets
 external_secrets_secret: golang-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
+k8s_exec_use_environment: false
+k8s_exec_environment_vars:
+  my_variable: ''

--- a/roles/vault_utils/tasks/push_parsed_secrets.yaml
+++ b/roles/vault_utils/tasks/push_parsed_secrets.yaml
@@ -12,6 +12,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault status -format=json
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_status_json
   until: "'stdout' in vault_status_json and (not (vault_status_json.stdout | from_json)['sealed'] | bool)"
   retries: 20
@@ -29,6 +30,7 @@
     pod: "{{ vault_pod }}"
     command:
       sh -c "vault list auth/{{ vault_hub }}/role | grep '{{ vault_hub }}-role'"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_role_cmd
   until:
     - vault_role_cmd.rc is defined

--- a/roles/vault_utils/tasks/push_secrets.yaml
+++ b/roles/vault_utils/tasks/push_secrets.yaml
@@ -10,6 +10,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault status -format=json
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_status_json
   until: "'stdout' in vault_status_json and (not (vault_status_json.stdout | from_json)['sealed'] | bool)"
   retries: 20
@@ -27,6 +28,7 @@
     pod: "{{ vault_pod }}"
     command:
       sh -c "vault list auth/{{ vault_hub }}/role | grep '{{ vault_hub }}-role'"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_role_cmd
   until:
     - vault_role_cmd.rc is defined

--- a/roles/vault_utils/tasks/vault_init.yaml
+++ b/roles/vault_utils/tasks/vault_init.yaml
@@ -15,6 +15,9 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault operator init -format=json
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+    http_proxy: "{{ ansible_env['http_proxy'] if not env_config.use_env else '' }}"
+    https_proxy: "{{ ansible_env['http_proxy'] if not env_config.use_env else '' }}"
   register: vault_init_json_out
   until: vault_init_json_out is not failed
   retries: 10

--- a/roles/vault_utils/tasks/vault_init.yaml
+++ b/roles/vault_utils/tasks/vault_init.yaml
@@ -15,9 +15,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault operator init -format=json
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
-    http_proxy: "{{ ansible_env['http_proxy'] if not env_config.use_env else '' }}"
-    https_proxy: "{{ ansible_env['http_proxy'] if not env_config.use_env else '' }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_init_json_out
   until: vault_init_json_out is not failed
   retries: 10

--- a/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -5,7 +5,7 @@
     pod: "{{ vault_pod }}"
     command: >
       bash -e -c "vault secrets list | grep -e '^{{ vault_base_path }}'"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: secrets_enabled
   failed_when: false
 
@@ -23,7 +23,7 @@
     pod: "{{ vault_pod }}"
     command: >
       bash -e -c "vault auth list | grep -e '^{{ vault_hub }}'"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: kubernetes_enabled
   failed_when: false
 
@@ -70,14 +70,14 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_global_policy }}/*\\\" {
         capabilities = {{ vault_global_capabilities }} }\" > /tmp/policy-{{ vault_global_policy }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure VP global policy
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_global_policy }}-secret /tmp/policy-{{ vault_global_policy }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure VP pushsecrets policy template
   kubernetes.core.k8s_exec:
@@ -86,7 +86,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" > /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Add metadata path to the pushsecrets policy
   kubernetes.core.k8s_exec:
@@ -95,7 +95,7 @@
       command: >
         bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
           capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure VP pushsecrets policy
   kubernetes.core.k8s_exec:
@@ -111,14 +111,14 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_hub }}/*\\\" {
         capabilities = {{ vault_hub_capabilities }} }\" > /tmp/policy-{{ vault_hub }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure policy for hub
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_hub }}-secret /tmp/policy-{{ vault_hub }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure kubernetes role for hub
   kubernetes.core.k8s_exec:
@@ -129,4 +129,4 @@
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ vault_hub }}-secret" ttl="{{ vault_hub_ttl }}"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"

--- a/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -5,6 +5,7 @@
     pod: "{{ vault_pod }}"
     command: >
       bash -e -c "vault secrets list | grep -e '^{{ vault_base_path }}'"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   register: secrets_enabled
   failed_when: false
 
@@ -13,6 +14,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault secrets enable -path="{{ vault_base_path }}" kv-v2
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   when: secrets_enabled.rc != 0
 
 - name: Is kubernetes backend already enabled
@@ -21,6 +23,7 @@
     pod: "{{ vault_pod }}"
     command: >
       bash -e -c "vault auth list | grep -e '^{{ vault_hub }}'"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   register: kubernetes_enabled
   failed_when: false
 
@@ -29,6 +32,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault auth enable -path={{ vault_hub }} kubernetes"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   when: kubernetes_enabled.rc != 0
 
 - name: Get token from service account secret {{ external_secrets_ns }}/{{ external_secrets_secret }}
@@ -55,6 +59,8 @@
         kubernetes_host={{ vault_hub_kubernetes_host }}
         kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         issuer=https://kubernetes.default.svc"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
+
 
 # This creates a {{ vault_global_policy }} policy that is applied to both hubs and spokes
 - name: Configure VP global policy template
@@ -64,12 +70,14 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_global_policy }}/*\\\" {
         capabilities = {{ vault_global_capabilities }} }\" > /tmp/policy-{{ vault_global_policy }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Configure VP global policy
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_global_policy }}-secret /tmp/policy-{{ vault_global_policy }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Configure VP pushsecrets policy template
   kubernetes.core.k8s_exec:
@@ -78,6 +86,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" > /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Add metadata path to the pushsecrets policy
   kubernetes.core.k8s_exec:
@@ -86,12 +95,14 @@
       command: >
         bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
           capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Configure VP pushsecrets policy
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_pushsecrets_policy }}-secret /tmp/policy-{{ vault_pushsecrets_policy }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
 
 - name: Configure policy template for hub
   kubernetes.core.k8s_exec:
@@ -100,12 +111,14 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_hub }}/*\\\" {
         capabilities = {{ vault_hub_capabilities }} }\" > /tmp/policy-{{ vault_hub }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Configure policy for hub
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ vault_hub }}-secret /tmp/policy-{{ vault_hub }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
 
 - name: Configure kubernetes role for hub
   kubernetes.core.k8s_exec:
@@ -116,3 +129,4 @@
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ vault_hub }}-secret" ttl="{{ vault_hub_ttl }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 

--- a/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -119,7 +119,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: bash -e -c "echo '{{ item.value['caBundle'] }}' > /tmp/{{ item.value['vault_path'] }}.ca"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -135,7 +135,7 @@
     command: bash -e -c "if vault auth list | grep -e ^'{{ item.value['vault_path'] }}'; then
         echo done; else
         vault auth enable -path='{{ item.value['vault_path'] }}' kubernetes; fi"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -152,7 +152,7 @@
         token_reviewer_jwt=\"{{ item.value['esoToken'] }}\"
         kubernetes_host=\"{{ item.value['server_api'] }}\"
         kubernetes_ca_cert=@/tmp/{{ item.value['vault_path'] }}.ca"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -167,7 +167,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ item.value['vault_path'] }}/*\\\" {
         capabilities = {{ vault_spoke_capabilities }} }\" > /tmp/policy-{{ item.value['vault_path'] }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -182,7 +182,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -197,7 +197,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -210,7 +210,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ item.value['vault_path'] }}-secret /tmp/policy-{{ item.value['vault_path'] }}.hcl"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -227,7 +227,7 @@
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_spoke_ttl }}"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined

--- a/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -119,6 +119,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: bash -e -c "echo '{{ item.value['caBundle'] }}' > /tmp/{{ item.value['vault_path'] }}.ca"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -134,6 +135,7 @@
     command: bash -e -c "if vault auth list | grep -e ^'{{ item.value['vault_path'] }}'; then
         echo done; else
         vault auth enable -path='{{ item.value['vault_path'] }}' kubernetes; fi"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -150,6 +152,7 @@
         token_reviewer_jwt=\"{{ item.value['esoToken'] }}\"
         kubernetes_host=\"{{ item.value['server_api'] }}\"
         kubernetes_ca_cert=@/tmp/{{ item.value['vault_path'] }}.ca"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -164,6 +167,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ item.value['vault_path'] }}/*\\\" {
         capabilities = {{ vault_spoke_capabilities }} }\" > /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -178,6 +182,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -192,6 +197,7 @@
     command: >
       bash -e -c "echo \"path \\\"secret/metadata/{{ vault_pushsecrets_policy }}/*\\\" {
         capabilities = {{ vault_pushsecrets_capabilities }} }\" >> /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -204,6 +210,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: "vault policy write {{ item.value['vault_path'] }}-secret /tmp/policy-{{ item.value['vault_path'] }}.hcl"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined
@@ -220,6 +227,7 @@
         bound_service_account_names="{{ external_secrets_sa }}"
         bound_service_account_namespaces="{{ external_secrets_ns }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_spoke_ttl }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ clusters_info | dict2items }}"
   when:
     - item.value['esoToken'] is defined

--- a/roles/vault_utils/tasks/vault_status.yaml
+++ b/roles/vault_utils/tasks/vault_status.yaml
@@ -28,7 +28,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault status -format=json
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: vault_status_json
   until: "'rc' in vault_status_json"
   retries: 20

--- a/roles/vault_utils/tasks/vault_status.yaml
+++ b/roles/vault_utils/tasks/vault_status.yaml
@@ -28,6 +28,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault status -format=json
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   register: vault_status_json
   until: "'rc' in vault_status_json"
   retries: 20

--- a/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/roles/vault_utils/tasks/vault_unseal.yaml
@@ -44,6 +44,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault operator unseal "{{ item }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ unseal_keys }}"
   loop_control:
     extended: true
@@ -55,6 +56,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ item }}"
     command: vault operator raft join http://{{ vault_pod }}.{{ vault_ns }}-internal:8200
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   register: join_raft_cluster_out
   until: join_raft_cluster_out is not failed
   retries: 10
@@ -72,6 +74,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ item.0 }}"
     command: vault operator unseal "{{ item.1 }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   loop: "{{ followers | product(unseal_keys) | list }}"
   loop_control:
     extended: true
@@ -85,4 +88,5 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault login "{{ root_token }}"
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
   when: vault_sealed

--- a/roles/vault_utils/tasks/vault_unseal.yaml
+++ b/roles/vault_utils/tasks/vault_unseal.yaml
@@ -44,7 +44,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault operator unseal "{{ item }}"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ unseal_keys }}"
   loop_control:
     extended: true
@@ -74,7 +74,7 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ item.0 }}"
     command: vault operator unseal "{{ item.1 }}"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   loop: "{{ followers | product(unseal_keys) | list }}"
   loop_control:
     extended: true
@@ -88,5 +88,5 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: vault login "{{ root_token }}"
-  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"	 
+  environment: "{{ k8s_exec_environment_vars | default ({}) if k8s_exec_use_environment }}"
   when: vault_sealed


### PR DESCRIPTION
We needed the ability to pass environment variables to the k8s_exec calls in the vault_utils roles.  Here's an example:
```
export EXTRA_PLAYBOOK_OPTS='-e {"k8s_exec_use_environment":true}  -e {"k8s_exec_environment_vars":{"https_proxy":"","http_proxy":""}} -e hide_sensitive_output=false' 
export VALUES_SECRET=~/values-secrets.yaml

./pattern.sh make load-secrets
```
Users can now pass environment variables by setting the k8s_exec_use_environment to true and passing a dictionary of key/value pairs through the k8s_exec_environment_vars.