### PR TITLE
mbp-935: Add Vault JWT configuration tasks

### DIFF
--- a/roles/vault_utils/README.md
+++ b/roles/vault_utils/README.md
@@ -34,6 +34,7 @@ external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
+vault_jwt_config: false
 ```
 
 ## Dependencies

--- a/roles/vault_utils/defaults/main.yml
+++ b/roles/vault_utils/defaults/main.yml
@@ -24,3 +24,4 @@ external_secrets_sa: golang-external-secrets
 external_secrets_secret: golang-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
+vault_jwt_config: false

--- a/roles/vault_utils/tasks/main.yml
+++ b/roles/vault_utils/tasks/main.yml
@@ -18,3 +18,8 @@
 - name: Load secrets
   ansible.builtin.import_tasks: push_secrets.yaml
   tags: push_secrets
+
+- name: Vault JWT configuration
+  ansible.builtin.import_tasks: vault_jwt.yaml
+  tags: vault_jwt
+  when: vault_jwt_config | default(false) | bool

--- a/roles/vault_utils/tasks/vault_jwt.yaml
+++ b/roles/vault_utils/tasks/vault_jwt.yaml
@@ -1,0 +1,78 @@
+---
+- name: Check vault auth configuration
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: vault auth list -format=json
+  register: vault_auth_json
+  until: "'rc' in vault_auth_json"
+  retries: 20
+  delay: 45
+  changed_when: false
+  failed_when: "'stdout_lines' not in vault_auth_json"
+
+- name: Set vault auth output json fact
+  ansible.builtin.set_fact:
+    vault_auth: "{{ vault_auth_json.stdout | from_json }}"
+  when: vault_auth_json.stdout_lines | length > 0
+
+- name: Set vault auth jwt fact
+  ansible.builtin.set_fact:
+    vault_auth_jwt: "{{ true if 'jwt/' in vault_auth else false }}"
+  when: vault_auth | length > 0
+
+- name: Enable jwt auth
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: vault auth enable jwt
+  when: not vault_auth_jwt
+
+- name: Get router CA certificate
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: openshift-ingress-operator
+    name: router-ca
+    api_version: v1
+  register: router_ca_cert
+  when: not vault_auth_jwt
+
+- name: Copy router CA certificate to vault
+  kubernetes.core.k8s_cp:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    content: "{{ router_ca_cert.resources[0].data['tls.crt'] | b64decode }}"
+    remote_path: /tmp/router-ca.crt
+  when: not vault_auth_jwt
+
+- name: Write JWT configuration
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      vault write auth/jwt/config
+        oidc_discovery_url={{ oidc_discovery_url }}
+        default_role={{ default_role | default('default') }}
+        oidc_discovery_ca_pem=@/tmp/router-ca.crt
+  when: not vault_auth_jwt
+
+- name: Write JWT role
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      vault write auth/jwt/role/{{ default_role | default('default') }}
+        role_type=jwt
+        user_claim=sub
+        bound_audiences={{ spiffe_audience }}
+        bound_subject={{ spiffe_subject }}
+        token_ttl={{ token_ttl | default('24h') }}
+        token_policies={{ vault_global_policy }}-secret
+  when: not vault_auth_jwt
+
+- name: Delete router CA certificate
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: rm -f /tmp/router-ca.crt
+  when: not vault_auth_jwt


### PR DESCRIPTION
This PR implements a series of tasks to configure JWT authentication in the `vault_utils` role.

It has been implemented in a separate file (`vault_jwt.yaml`) to avoid mixing it with other tasks, and a tag and conditional have been added so that it is executed only in certain scenarios. It is disabled by default.

I tested using:
```
export TASK="vault_jwt"
export OIDC_DISCOVERY_URL="https://oidc-discovery.apps.example.lab
export SPIFFE_AUDIENCE="QTODO"
export SPIFFE_SUBJECT="spiffe://apps.example.lab/ns/spire-federated-identities/sa/workload-app"

ansible-playbook -t "${TASK}" \
  -e pattern_name="${PATTERN_NAME}" \
  -e pattern_dir="${PATTERNPATH}" \
  -e vault_jwt_config="${VAULT_JWT_CONFIG}" \
  -e oidc_discovery_url="${OIDC_DISCOVERY_URL}" \
  -e spiffe_audience="${SPIFFE_AUDIENCE}" \
  -e spiffe_subject="${SPIFFE_SUBJECT}" \
  ${EXTRA_PLAYBOOK_OPTS} "rhvp.cluster_utils.vault"
```