### PR TITLE
Add alphanumericPolicy to Vault

### DIFF
--- a/plugins/filter/parse_acm_secrets.py
+++ b/plugins/filter/parse_acm_secrets.py
@@ -46,5 +46,6 @@ def parse_acm_secrets(secrets):
 
 
 class FilterModule:
+
     def filters(self):
         return {"parse_acm_secrets": parse_acm_secrets}

--- a/plugins/module_utils/load_secrets_v2.py
+++ b/plugins/module_utils/load_secrets_v2.py
@@ -38,7 +38,13 @@ default_vp_vault_policies = {
         'rule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\n'
         'rule "charset" { charset = "0123456789" min-chars = 1 }\n'
         'rule "charset" { charset = "!@#%^&*" min-chars = 1 }\n'
-    )
+    ),
+    "alphanumericPolicy": (
+        "length=32\n"
+        'rule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\n'
+        'rule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\n'
+        'rule "charset" { charset = "0123456789" min-chars = 1 }\n'
+    ),
 }
 
 

--- a/plugins/module_utils/parse_secrets_v2.py
+++ b/plugins/module_utils/parse_secrets_v2.py
@@ -38,7 +38,13 @@ default_vp_vault_policies = {
         'rule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\n'
         'rule "charset" { charset = "0123456789" min-chars = 1 }\n'
         'rule "charset" { charset = "!@#%^&*" min-chars = 1 }\n'
-    )
+    ),
+    "alphanumericPolicy": (
+        "length=32\n"
+        'rule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\n'
+        'rule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\n'
+        'rule "charset" { charset = "0123456789" min-chars = 1 }\n'
+    ),
 }
 
 secret_store_namespace = "validated-patterns-secrets"

--- a/tests/unit/test_parse_secrets.py
+++ b/tests/unit/test_parse_secrets.py
@@ -717,6 +717,7 @@ class TestMyModule(unittest.TestCase):
             ds_eq(
                 ret["vault_policies"],
                 {
+                    "alphanumericPolicy": 'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n',  # noqa: E501
                     "basicPolicy": 'length=10\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n',  # noqa: E501
                     "validatedPatternDefaultPolicy": 'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n',  # noqa: E501
                 },

--- a/tests/unit/test_util_datastructures.py
+++ b/tests/unit/test_util_datastructures.py
@@ -30,6 +30,12 @@ DEFAULT_KUBERNETES_SECRET_OBJECT = {
 }
 
 DEFAULT_VAULT_POLICIES = {
+    "alphanumericPolicy": (
+        "length=32\n"
+        'rule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\n'  # noqa: E501
+        'rule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\n'  # noqa: E501
+        'rule "charset" { charset = "0123456789" min-chars = 1 }\n'
+    ),
     "validatedPatternDefaultPolicy": (
         "length=20\n"
         'rule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\n'  # noqa: E501

--- a/tests/unit/test_vault_load_secrets_v2.py
+++ b/tests/unit/test_vault_load_secrets_v2.py
@@ -121,11 +121,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 5
+            assert mock_run_command.call_count == 6
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -170,11 +174,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 11
+            assert mock_run_command.call_count == 12
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -343,11 +351,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 2
+            assert mock_run_command.call_count == 3
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -378,11 +390,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 7
+            assert mock_run_command.call_count == 8
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -433,11 +449,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 4
+            assert mock_run_command.call_count == 5
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -508,11 +528,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 2
+            assert mock_run_command.call_count == 3
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -562,11 +586,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 6
+            assert mock_run_command.call_count == 7
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -634,11 +662,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 5
+            assert mock_run_command.call_count == 6
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(
@@ -698,11 +730,15 @@ class TestMyModule(unittest.TestCase):
             self.assertTrue(
                 result.exception.args[0]["changed"]
             )  # ensure result is changed
-            assert mock_run_command.call_count == 5
+            assert mock_run_command.call_count == 6
 
         calls = [
             call(
                 'echo \'length=20\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\nrule "charset" { charset = "!@#%^&*" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/validatedPatternDefaultPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/validatedPatternDefaultPolicy  policy=@/tmp/validatedPatternDefaultPolicy.hcl\'',  # noqa: E501
+                attempts=3,
+            ),
+            call(
+                'echo \'length=32\nrule "charset" { charset = "abcdefghijklmnopqrstuvwxyz" min-chars = 1 }\nrule "charset" { charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" min-chars = 1 }\nrule "charset" { charset = "0123456789" min-chars = 1 }\n\' | oc exec -n vault vault-0 -i -- sh -c \'cat - > /tmp/alphanumericPolicy.hcl\';oc exec -n vault vault-0 -i -- sh -c \'vault write sys/policies/password/alphanumericPolicy  policy=@/tmp/alphanumericPolicy.hcl\'',  # noqa: E501
                 attempts=3,
             ),
             call(


### PR DESCRIPTION
This commit adds a new password policy, `alphanumericPolicy`, to Vault.

The reason for adding this policy is that we have found problems with auto-generated passwords in some contexts, specifically when working with **Keycloak**. In that case, passwords that use the character `%` trigger an error if used as `client-secret`.

With this additional policy, we can set a different policy for that secret and generate a random password using only alphanumeric characters.