### PR TITLE
Try and work with new and old eso namespaces

### DIFF
--- a/roles/vault_utils/README.md
+++ b/roles/vault_utils/README.md
@@ -30,7 +30,9 @@ vault_base_path: "secret"
 vault_path: "{{ vault_base_path }}/{{ vault_hub }}"
 vault_hub_ttl: "15m"
 vault_pki_max_lease_ttl: "8760h"
+# "external-secrets" is the namespace when using the downstream openshift-external-secrets chart
 external_secrets_ns: golang-external-secrets
+# "ocp-external-secrets" is the service account name when using the downstream openshift-external-secrets chart
 external_secrets_sa: golang-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"

--- a/roles/vault_utils/defaults/main.yml
+++ b/roles/vault_utils/defaults/main.yml
@@ -19,9 +19,13 @@ vault_global_policy: global
 vault_global_capabilities: '[\\\"read\\\"]'
 vault_pushsecrets_policy: pushsecrets
 vault_pushsecrets_capabilities: '[\\\"create\\\",\\\"read\\\",\\\"update\\\",\\\"delete\\\"]'
-external_secrets_ns: golang-external-secrets
-external_secrets_sa: golang-external-secrets
-external_secrets_secret: golang-external-secrets
+legacy_external_secrets_ns: golang-external-secrets
+legacy_external_secrets_sa: golang-external-secrets
+legacy_external_secrets_secret: golang-external-secrets
+external_secrets_ns: external-secrets
+# The service account cannot be called "external-secrets" as that SA is used by the downstream ESO
+external_secrets_sa: ocp-external-secrets
+external_secrets_secret: ocp-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
 vault_jwt_config: false

--- a/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -31,15 +31,38 @@
     command: "vault auth enable -path={{ vault_hub }} kubernetes"
   when: kubernetes_enabled.rc != 0
 
-- name: Get token from service account secret {{ external_secrets_ns }}/{{ external_secrets_secret }}
+- name: Check for external secrets namespace and secret
   no_log: '{{ hide_sensitive_output | default(true) }}'
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
     name: "{{ external_secrets_secret }}"
     api_version: v1
-  register: token_data
-  failed_when: token_data.resources | length == 0
+  register: external_secrets_token_data
+  failed_when: false
+
+- name: Check for legacy external secrets namespace and secret
+  no_log: '{{ hide_sensitive_output | default(true) }}'
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: "{{ legacy_external_secrets_ns }}"
+    name: "{{ legacy_external_secrets_secret }}"
+    api_version: v1
+  register: legacy_external_secrets_token_data
+  failed_when: false
+  when: external_secrets_token_data.resources | length == 0
+
+- name: Set external secrets configuration to use (prefer new over legacy)
+  ansible.builtin.set_fact:
+    active_external_secrets_ns: "{{ external_secrets_ns if external_secrets_token_data.resources | length > 0 else legacy_external_secrets_ns }}"
+    active_external_secrets_sa: "{{ external_secrets_sa if external_secrets_token_data.resources | length > 0 else legacy_external_secrets_sa }}"
+    active_external_secrets_secret: "{{ external_secrets_secret if external_secrets_token_data.resources | length > 0 else legacy_external_secrets_secret }}"
+    token_data: "{{ external_secrets_token_data if external_secrets_token_data.resources | length > 0 else legacy_external_secrets_token_data }}"
+
+- name: Fail if neither external secrets nor legacy external secrets are found
+  ansible.builtin.fail:
+    msg: "Neither {{ external_secrets_ns }}/{{ external_secrets_secret }} nor {{ legacy_external_secrets_ns }}/{{ legacy_external_secrets_secret }} secret found"
+  when: token_data.resources | length == 0
 
 - name: Set sa_token fact
   no_log: '{{ hide_sensitive_output | default(true) }}'
@@ -113,6 +136,6 @@
     pod: "{{ vault_pod }}"
     command: >
       vault write auth/"{{ vault_hub }}"/role/"{{ vault_hub }}"-role
-        bound_service_account_names="{{ external_secrets_sa }}"
-        bound_service_account_namespaces="{{ external_secrets_ns }}"
+        bound_service_account_names="{{ active_external_secrets_sa }}"
+        bound_service_account_namespaces="{{ active_external_secrets_ns }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ vault_hub }}-secret" ttl="{{ vault_hub_ttl }}"

--- a/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -121,7 +121,7 @@
   ansible.builtin.set_fact:
     validate_certs_api_endpoint: "{{ not letsencrypt.api_endpoint | default(True) | bool }}"
 
-- name: Fetch remote ansible to remote cluster
+- name: Fetch remote external secrets from remote cluster
   kubernetes.core.k8s_info:
     api_key: "{{ item.value['bearerToken'] }}"
     ca_cert: /tmp/{{ item.key }}.ca
@@ -150,13 +150,54 @@
   loop_control:
     label: "{{ item.key }}"
 
-# 'token' will be empty if the remote cluster has no golang-external-secret
+- name: Fetch remote legacy external secrets from remote cluster
+  kubernetes.core.k8s_info:
+    api_key: "{{ item.value['bearerToken'] }}"
+    ca_cert: /tmp/{{ item.key }}.ca
+    host: "{{ item.value['server_api'] }}"
+    kind: Secret
+    namespace: "{{ legacy_external_secrets_ns }}"
+    name: "{{ legacy_external_secrets_secret }}"
+    api_version: v1
+    validate_certs: "{{ validate_certs_api_endpoint }}"
+  register: remote_legacy_external_secrets_sa
+  # We are allowed to ignore errors here because a spoke might be down or unreachable
+  # if a spoke is not reachable then its ['token'] field will not be set which
+  # will leave the ['esoToken'] field empty in the dict which will make it so that
+  # the spoke gets skipped
+  ignore_errors: true
+  # We add no_log: '{{ hide_sensitive_output | default(true) }}' here because in case of a remote failure secret bits might
+  # end up in the log. Unfortunately ansible is currently not easily able to control
+  # output in a loop (see
+  # https://serverfault.com/questions/1059530/how-to-not-print-items-in-an-ansible-loop-error-without-no-log)
+  no_log: '{{ hide_sensitive_output | default(true) }}'
+  when:
+    - clusters_info[item.key]['bearerToken'] is defined
+    - clusters_info[item.key]['server_api'] is defined
+    - clusters_info[item.key]['caBundle'] is defined
+  loop: "{{ clusters_info | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+# 'token' will be empty if the remote cluster has no external-secrets
 # app configured and running
-- name: Loop over returned ESO tokens
+- name: Loop over returned external secrets tokens
   ansible.builtin.set_fact:
-    clusters_info: "{{ clusters_info | default({}) | combine({item['item']['key']: {'esoToken': item['resources'][0]['data']['token'] | b64decode}}, recursive=True) }}"
+    clusters_info: "{{ clusters_info | default({}) | combine({item['item']['key']: {'esoToken': item['resources'][0]['data']['token'] | b64decode, 'activeExternalSecretsNs': external_secrets_ns, 'activeExternalSecretsSa': external_secrets_sa}}, recursive=True) }}"
   loop: "{{ remote_external_secrets_sa.results }}"
   when: item['resources'][0]['data']['token'] is defined
+  loop_control:
+    label: "{{ item['item']['key'] }}"
+
+# 'token' will be empty if the remote cluster has no legacy golang-external-secret
+# app configured and running - only check legacy if regular external secrets were not found
+- name: Loop over returned legacy external secrets tokens
+  ansible.builtin.set_fact:
+    clusters_info: "{{ clusters_info | default({}) | combine({item['item']['key']: {'esoToken': item['resources'][0]['data']['token'] | b64decode, 'activeExternalSecretsNs': legacy_external_secrets_ns, 'activeExternalSecretsSa': legacy_external_secrets_sa}}, recursive=True) }}"
+  loop: "{{ remote_legacy_external_secrets_sa.results }}"
+  when:
+    - item['resources'][0]['data']['token'] is defined
+    - clusters_info[item['item']['key']]['esoToken'] is not defined
   loop_control:
     label: "{{ item['item']['key'] }}"
 
@@ -274,8 +315,8 @@
     pod: "{{ vault_pod }}"
     command: >
       vault write auth/"{{ item.value['vault_path'] }}"/role/"{{ item.value['vault_path'] }}"-role
-        bound_service_account_names="{{ external_secrets_sa }}"
-        bound_service_account_namespaces="{{ external_secrets_ns }}"
+        bound_service_account_names="{{ item.value['activeExternalSecretsSa'] }}"
+        bound_service_account_namespaces="{{ item.value['activeExternalSecretsNs'] }}"
         policies="default,{{ vault_global_policy }}-secret,{{ vault_pushsecrets_policy }}-secret,{{ item.value['vault_path'] }}-secret" ttl="{{ vault_spoke_ttl }}"
   loop: "{{ clusters_info | dict2items }}"
   when:


### PR DESCRIPTION
The "old/upstream" golang-external-secrets chart uses the
golang-external-secret namespace and serviceaccount.

The "new/downstream" openshift-external-secrets chart uses
the "external-secrets" and "external-secrets-operator" namespaces and
the "ocp-external-secrets" service account.

We need to cater to both possibilities in our vault setup job.

Eventually once we stop supporting the old way we can drop any reference
to golang-external-secrets
