### PR TITLE
mbp-1005: Implement multi-role support for Vault JWT configuration

### DIFF
--- a/roles/vault_utils/defaults/main.yml
+++ b/roles/vault_utils/defaults/main.yml
@@ -29,3 +29,4 @@ external_secrets_secret: ocp-external-secrets
 unseal_secret: "vaultkeys"
 unseal_namespace: "imperative"
 vault_jwt_config: false
+vault_jwt_roles: []

--- a/roles/vault_utils/tasks/vault_jwt.yaml
+++ b/roles/vault_utils/tasks/vault_jwt.yaml
@@ -102,51 +102,11 @@
         not jwt_config_oidc_discovery_url == oidc_discovery_url or
         not jwt_config_default_role == default_role | default('default')
 
-- name: Get JWT role configuration
-  kubernetes.core.k8s_exec:
-    namespace: "{{ vault_ns }}"
-    pod: "{{ vault_pod }}"
-    command: >
-      vault read auth/jwt/role/{{ default_role | default('default') }} -format=json
-  register: jwt_role_config_json
-  changed_when: false
-  failed_when: false
-
-- name: Set jwt_role fact
-  ansible.builtin.set_fact:
-    jwt_role: "{{ true if jwt_role_config_json.stdout_lines | length > 0 else false }}"
-
-- name: Set JWT role configuration fact
-  ansible.builtin.set_fact:
-    jwt_role_config: "{{ jwt_role_config_json.stdout | from_json }}"
-  when: jwt_role
-
-- name: Set JWT role configuration facts
-  ansible.builtin.set_fact:
-    jwt_role_config_bound_audiences: "{{ jwt_role_config.data.bound_audiences[0] | default('') }}"
-    jwt_role_config_bound_subject: "{{ jwt_role_config.data.bound_subject }}"
-    jwt_role_config_token_ttl: "{{ jwt_role_config.data.token_ttl }}"
-    jwt_role_config_token_policies: "{{ jwt_role_config.data.token_policies[0] | default('') }}"
-  when: jwt_role
-
-- name: Write JWT role
-  kubernetes.core.k8s_exec:
-    namespace: "{{ vault_ns }}"
-    pod: "{{ vault_pod }}"
-    command: >
-      vault write auth/jwt/role/{{ default_role | default('default') }}
-        role_type=jwt
-        user_claim=sub
-        bound_audiences={{ spiffe_audience }}
-        bound_subject={{ spiffe_subject }}
-        token_ttl={{ token_ttl | default('86400') }}
-        token_policies={{ role_policy | default('{}-secret'.format(vault_global_policy)) }}
-  when: not vault_auth_jwt or
-        not jwt_role or
-        not jwt_role_config_bound_audiences == spiffe_audience or
-        not jwt_role_config_bound_subject == spiffe_subject or
-        not jwt_role_config_token_ttl == token_ttl | default('86400') or
-        not jwt_role_config_token_policies == role_policy | default('{}-secret'.format(vault_global_policy))
+- name: Run JWT role tasks
+  ansible.builtin.include_tasks: vault_jwt_roles.yaml
+  loop: "{{ vault_jwt_roles | default([]) }}"
+  loop_control:
+    loop_var: jwt_role
 
 - name: Delete router CA certificate
   kubernetes.core.k8s_exec:

--- a/roles/vault_utils/tasks/vault_jwt_roles.yaml
+++ b/roles/vault_utils/tasks/vault_jwt_roles.yaml
@@ -1,0 +1,45 @@
+---
+- name: Get JWT role configuration
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      vault read auth/jwt/role/{{ jwt_role.name }} -format=json
+  register: jwt_role_config_json
+  changed_when: false
+  failed_when: false
+
+- name: Set jwt_role fact
+  ansible.builtin.set_fact:
+    jwt_role_exists: "{{ true if jwt_role_config_json.stdout_lines | length > 0 else false }}"
+
+- name: Set JWT role configuration fact
+  ansible.builtin.set_fact:
+    jwt_role_config: "{{ jwt_role_config_json.stdout | from_json }}"
+  when: jwt_role_exists
+
+- name: Set JWT role configuration facts
+  ansible.builtin.set_fact:
+    jwt_role_config_bound_audiences: "{{ jwt_role_config.data.bound_audiences[0] | default('') }}"
+    jwt_role_config_bound_subject: "{{ jwt_role_config.data.bound_subject }}"
+    jwt_role_config_token_ttl: "{{ jwt_role_config.data.token_ttl }}"
+    jwt_role_config_token_policies: "{{ jwt_role_config.data.token_policies[0] | default('') }}"
+  when: jwt_role_exists
+
+- name: Write JWT role
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      vault write auth/jwt/role/{{ jwt_role.name }}
+        role_type=jwt
+        user_claim=sub
+        bound_audiences={{ jwt_role.audience }}
+        bound_subject={{ jwt_role.subject }}
+        token_ttl={{ jwt_role.ttl | default('86400') }}
+        token_policies={{ jwt_role.policies | default(['{}-secret'.format(vault_global_policy)]) | join(',') }}
+  when: not jwt_role_exists or
+        not jwt_role_config_bound_audiences == jwt_role.audience or
+        not jwt_role_config_bound_subject == jwt_role.subject or
+        not jwt_role_config_token_ttl == jwt_role.ttl | default('86400') or
+        not jwt_role_config_token_policies == jwt_role.policies | default(['{}-secret'.format(vault_global_policy)]) | join(',')


### PR DESCRIPTION
This PR implements support for multiple roles in the Hashicorp Vault JWT configuration.
This only affects JWT and it has no effect on other Vault components.
We need this changes for Zero Trust Validated Pattern.
I have tested it and it works correctly, but I'm open to changes if you find any bugs.