### PR TITLE
Add role/playbook for creating machinesets in an existing cluster

### DIFF
--- a/playbooks/create_machineset.yml
+++ b/playbooks/create_machineset.yml
@@ -1,0 +1,7 @@
+---
+- name: Create MachineSet Based on Existing MachineSet(s)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - role: create_machineset

--- a/roles/create_machineset/tasks/aws_create_machineset_manifests.yml
+++ b/roles/create_machineset/tasks/aws_create_machineset_manifests.yml
@@ -1,0 +1,30 @@
+---
+- name: Set Name and Region
+  ansible.builtin.set_fact:
+    infrastructure_name: "{{ cluster_info.resources[0].status.infrastructureName }}"
+    infrastructure_region: "{{ cluster_info.resources[0].status.platformStatus.aws.region }}"
+
+- name: Query Existing MachineSet(s)
+  kubernetes.core.k8s_info:
+    api_version: machine.openshift.io/v1beta1
+    kind: MachineSet
+    namespace: openshift-machine-api
+  register: cluster_machinesets
+
+- name: Extract Target MachineSet(s)
+  ansible.builtin.set_fact:
+    target_machineset_resources: "{{ cluster_machinesets.resources[0 : max_machineset_count | int] }}"
+
+- name: Ensure Two Machine Minimum
+  ansible.builtin.set_fact:
+    machineset_replicas: 2
+  when: ensure_two_machine_minimum | bool and target_machineset_resources | length == 1
+
+- name: Apply AWS Template
+  ansible.builtin.template:
+    src: templates/aws_machineset.j2
+    dest: "/tmp/machineset_{{ idx }}.yaml"
+    mode: "0644"
+  loop: "{{ target_machineset_resources }}"
+  loop_control:
+    index_var: idx

--- a/roles/create_machineset/tasks/main.yml
+++ b/roles/create_machineset/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Query Cluster Infrastructure
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: cluster_info
+
+- name: Get Cluster Platform
+  ansible.builtin.set_fact:
+    cluster_platform: "{{ cluster_info.resources[0].status.platform | upper }}"
+
+- name: Create AWS MachineSet Manifests
+  when: cluster_platform == "AWS"
+  ansible.builtin.include_tasks: aws_create_machineset_manifests.yml
+
+- name: Print Manifests on Dry Run
+  when: dry_run
+  ansible.builtin.debug:
+    var: lookup("ansible.builtin.file", "/tmp/machineset_{{ idx }}.yaml")
+  loop: "{{ target_machineset_resources }}"
+  loop_control:
+    index_var: idx
+
+- name: Apply MachineSet Manifest
+  when: not dry_run
+  kubernetes.core.k8s:
+    state: present
+    src: "/tmp/machineset_{{ idx }}.yaml"
+  loop: "{{ target_machineset_resources }}"
+  loop_control:
+    index_var: idx

--- a/roles/create_machineset/templates/aws_machineset.j2
+++ b/roles/create_machineset/templates/aws_machineset.j2
@@ -1,0 +1,57 @@
+---
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
+{% if machineset_labels %}
+{{ machineset_labels | from_yaml | to_nice_yaml(indent=2) | indent(4, first=True) }}{% endif %}
+  name: "{{ infrastructure_name }}-{{ machineset_name }}-{{ item.spec.template.spec.providerSpec.value.placement.availabilityZone }}"
+  namespace: openshift-machine-api
+spec:
+  replicas: {{ machineset_replicas | int }}
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
+      machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}-{{ item.spec.template.spec.providerSpec.value.placement.availabilityZone }}"
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
+        machine.openshift.io/cluster-api-machine-role: "{{ machineset_machine_role }}"
+        machine.openshift.io/cluster-api-machine-type: "{{ machineset_machine_type }}"
+        machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}-{{ item.spec.template.spec.providerSpec.value.placement.availabilityZone }}"
+    spec:
+{% if machineset_taints %}
+      taints:
+{{ machineset_taints | from_yaml | to_nice_yaml(indent=2) | indent(8, first=True) }}{% endif %}
+      metadata:
+        labels:
+{% if machineset_node_labels %}
+{{ machineset_node_labels | from_yaml | to_nice_yaml(indent=2) | indent(10, first=True) }}{% endif %}
+      providerSpec:
+        value:
+          ami:
+            id: "{{ item.spec.template.spec.providerSpec.value.ami.id }}"
+          apiVersion: {{ machineset_api_version }}
+          blockDevices: {{ item.spec.template.spec.providerSpec.value.blockDevices }}
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: "{{ infrastructure_name }}-worker-profile"
+          instanceType: "{{ machineset_instance_type }}"
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: "{{ item.spec.template.spec.providerSpec.value.placement.availabilityZone }}"
+            region: "{{ infrastructure_region }}"
+          securityGroups: {{ item.spec.template.spec.providerSpec.value.securityGroups }}
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - "{{ item.spec.template.spec.providerSpec.value.subnet.filters[0]['values'][0] }}"
+          tags: {{ item.spec.template.spec.providerSpec.value.tags }}
+          userDataSecret:
+            name: "{{ machineset_user_data_secret }}"
+            namespace: "{{ machineset_user_data_namespace }}"

--- a/roles/create_machineset/vars/main.yml
+++ b/roles/create_machineset/vars/main.yml
@@ -1,0 +1,17 @@
+dry_run: false
+ensure_two_machine_minimum: true
+kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+machineset_api_version: awsproviderconfig.openshift.io/v1beta1
+machineset_instance_type: m5.metal
+machineset_labels:
+  edge-gitops-role: kubevirt-worker
+machineset_machine_role: worker
+machineset_machine_type: worker
+machineset_name: metal-worker
+machineset_node_labels:
+  node-role.kubernetes.io/worker: ""
+machineset_replicas: 1
+machineset_taints: []
+machineset_user_data_namespace: openshift-machine-api
+machineset_user_data_secret: worker-user-data
+max_machineset_count: 2


### PR DESCRIPTION
Allows patterns to create gpu nodes, metal nodes, etc. to existing clusters via the imperative container