### PR TITLE
Retry the JWT discovery configuration task when it fails

### DIFF
--- a/roles/vault_utils/tasks/vault_jwt.yaml
+++ b/roles/vault_utils/tasks/vault_jwt.yaml
@@ -51,10 +51,13 @@
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
     command: >
-      vault read auth/jwt/config -format=json
+      vault read -format=json auth/jwt/config
   register: jwt_discovery_config_json
+  until: jwt_discovery_config_json.rc is defined and jwt_discovery_config_json.rc == 0
+  retries: 10
+  delay: 30
   changed_when: false
-  failed_when: false
+  failed_when: jwt_discovery_config_json.rc != 0
 
 - name: Set jwt_discovery fact
   ansible.builtin.set_fact:


### PR DESCRIPTION
This change makes the `vault read auth/jwt/config` step in `vault_jwt.yaml` resilient to transient failures (for example when the Vault pod or API is not ready yet)