### PR TITLE
Replace retries by default value in jwt_discovery fact

### DIFF
--- a/roles/vault_utils/tasks/vault_jwt.yaml
+++ b/roles/vault_utils/tasks/vault_jwt.yaml
@@ -53,15 +53,12 @@
     command: >
       vault read -format=json auth/jwt/config
   register: jwt_discovery_config_json
-  until: jwt_discovery_config_json.rc is defined and jwt_discovery_config_json.rc == 0
-  retries: 10
-  delay: 30
   changed_when: false
-  failed_when: jwt_discovery_config_json.rc != 0
+  failed_when: false
 
 - name: Set jwt_discovery fact
   ansible.builtin.set_fact:
-    jwt_discovery: "{{ true if jwt_discovery_config_json.stdout_lines | length > 0 else false }}"
+    jwt_discovery: "{{ true if jwt_discovery_config_json.stdout_lines | default([]) | length > 0 else false }}"
 
 - name: Set JWT discovery configuration fact
   ansible.builtin.set_fact:


### PR DESCRIPTION
This change updates the JWT discovery step in `vault_jwt.yaml` so it no longer uses an until / retries / delay loop. The task is allowed to finish with a non-zero exit (`failed_when: false`), which matches the intent of a probe rather than a hard requirement for Vault to succeed immediately.

The `jwt_discovery` fact now treats missing **stdout_lines** safely with `| default([])` before checking length, so a failed or empty command still yields a consistent boolean.