### PR TITLE
feat: Add list cap. to pushsecrets

### DIFF
--- a/roles/vault_utils/defaults/main.yml
+++ b/roles/vault_utils/defaults/main.yml
@@ -18,7 +18,7 @@ vault_spoke_ttl: "15m"
 vault_global_policy: global
 vault_global_capabilities: '[\\\"read\\\"]'
 vault_pushsecrets_policy: pushsecrets
-vault_pushsecrets_capabilities: '[\\\"create\\\",\\\"read\\\",\\\"update\\\",\\\"delete\\\"]'
+vault_pushsecrets_capabilities: '[\\\"create\\\",\\\"read\\\",\\\"update\\\",\\\"list\\\",\\\"delete\\\"]'
 legacy_external_secrets_ns: golang-external-secrets
 legacy_external_secrets_sa: golang-external-secrets
 legacy_external_secrets_secret: golang-external-secrets


### PR DESCRIPTION
This is needed if we want to use ESO's ability to find secrets based
on a regexp.
