### PR TITLE
Improve the vault pod check

### DIFF
--- a/roles/vault_utils/tasks/vault_status.yaml
+++ b/roles/vault_utils/tasks/vault_status.yaml
@@ -16,7 +16,7 @@
     vault_ns_rc is not defined or
     'resources' not in vault_ns_rc
 
-- name: Check if the vault pod is present
+- name: Check if the vault pod is present and running
   kubernetes.core.k8s_info:
     kind: Pod
     namespace: "{{ vault_ns }}"
@@ -26,7 +26,10 @@
     vault_pod_rc is defined and
     'resources' in vault_pod_rc and
     vault_pod_rc.resources is defined and
-    vault_pod_rc.resources | length > 0
+    vault_pod_rc.resources | length > 0 and
+    vault_pod_rc.resources[0].status.containerStatuses is defined and
+    vault_pod_rc.resources[0].status.containerStatuses | length > 0 and
+    vault_pod_rc.resources[0].status.containerStatuses[0].started | default(false)
   retries: 20
   delay: 45
   failed_when: >-


### PR DESCRIPTION
The "Check if the vault pod is present" task (line 19-34) only checks
that the Pod resource exists, not that the container is actually
running. When the vault container is still in ContainerCreating, the
subsequent k8s_exec crashes with a Python ValueError in the k8s_exec
module (not a normal ansible failure), which prevents the until retry
loop from working. The issue was seen while testing the UI in the secret
injection pod

Tested on mcg
