### PR TITLE
Add support for .main.variant and TARGET_VARIANT

### DIFF
--- a/roles/install_settings/tasks/main.yml
+++ b/roles/install_settings/tasks/main.yml
@@ -44,8 +44,9 @@
   ansible.builtin.set_fact:
     clustergroup_opt: >-
       {{
-        "" if (target_clustergroup | default("") | trim == "")
-        else "--set main.clusterGroupName=%s" | format(target_clustergroup)
+        "--set main.clusterGroupName=%s --set main.variant=null" | format(target_variant) if (_target_clustergroup_override | default("") | trim != "")
+        else "--set main.variant=%s --set main.clusterGroupName=null" | format(target_variant) if (_target_variant_override | default("") | trim != "")
+        else ""
       }}
 
 - name: Build include_crds_opt

--- a/roles/install_settings/tasks/resolve_overrides.yml
+++ b/roles/install_settings/tasks/resolve_overrides.yml
@@ -77,14 +77,41 @@
           Alternatively, pass the remote explicitly via the 'target_origin' variable
           or 'TARGET_ORIGIN' environment variable.
 
-- name: Resolve target_clustergroup
+- name: Resolve TARGET_CLUSTERGROUP override
   ansible.builtin.set_fact:
-    target_clustergroup: >-
+    _target_clustergroup_override: >-
       {{
         target_clustergroup
           | default(lookup("env", "TARGET_CLUSTERGROUP"), true)
-          | default(main_clustergroup, true)
+          | default("", true)
           | trim
+      }}
+
+- name: Resolve TARGET_VARIANT override
+  ansible.builtin.set_fact:
+    _target_variant_override: >-
+      {{
+        target_variant
+          | default(lookup("env", "TARGET_VARIANT"), true)
+          | default("", false)
+          | trim
+       }}
+
+- name: Ensure TARGET_CLUSTERGROUP and TARGET_VARIANT are not both set
+  ansible.builtin.assert:
+    that: _target_clustergroup_override == "" or _target_variant_override == ""
+    fail_msg: |
+      Both target_clustergroup/TARGET_CLUSTERGROUP and target_variant/TARGET_VARIANT are set.
+      Please use only one of these to specify the cluster group name.
+
+- name: Resolve target_variant
+  ansible.builtin.set_fact:
+    target_variant: >-
+      {{
+        (_target_clustergroup_override if _target_clustergroup_override != ""
+         else _target_variant_override if _target_variant_override != ""
+         else main_variant)
+        | trim
       }}
 
 - name: Resolve token_secret

--- a/roles/pattern_settings/tasks/main.yml
+++ b/roles/pattern_settings/tasks/main.yml
@@ -22,13 +22,21 @@
           | default((values_global.global.pattern | string | trim), true)
       }}
 
-- name: Ensure main.clusterGroupName is set
-  ansible.builtin.assert:
-    that: (values_global.main.clusterGroupName | default('') | string | trim) != ""
-    fail_msg: |
-      values-global.yaml does not define .main.clusterGroupName.
-      Please set a value for clusterGroupName under the 'main' key.
-
-- name: Set fact for main clustergroup
+- name: Set helper booleans for main.clusterGroupName and main.variant
   ansible.builtin.set_fact:
-    main_clustergroup: "{{ values_global.main.clusterGroupName | string | trim }}"
+    _has_clustergroupname: "{{ (values_global.main.clusterGroupName | default('') | string | trim) != '' }}"
+    _has_variant: "{{ (values_global.main.variant | default('') | string | trim) != '' }}"
+
+- name: Ensure exactly one of main.clusterGroupName or main.variant is set
+  ansible.builtin.assert:
+    that:
+      - _has_clustergroupname or _has_variant
+      - not (_has_clustergroupname and _has_variant)
+    fail_msg: |
+      values-global.yaml must define exactly one of .main.clusterGroupName or .main.variant (not both).
+      Please set one of these values under the 'main' key.
+
+- name: Set fact for main variant
+  ansible.builtin.set_fact:
+    main_variant: >-
+      {{ (values_global.main.clusterGroupName if _has_clustergroupname else values_global.main.variant) | string | trim }}

--- a/roles/validate_prereq/tasks/main.yml
+++ b/roles/validate_prereq/tasks/main.yml
@@ -7,7 +7,7 @@
 
     - name: Get length of target clustergroup
       ansible.builtin.set_fact:
-        _clustergroup_name_len: "{{ target_clustergroup | length }}"
+        _clustergroup_name_len: "{{ target_variant | length }}"
 
     - name: Ensure ArgoCD will have valid DNS hostname based on pattern name and clustergroup lengths
       ansible.builtin.assert:
@@ -17,7 +17,7 @@
             -> {%raw%}{{ .Values.clusterGroup.name }}-gitops-server-{{ .Values.global.pattern }}-{{ .Values.clusterGroup.name }}{%endraw%}
           To stay under the 63-character DNS limit, the variable part of the name must be less than 47 characters:
             (2 * length of 'clusterGroup.name') + length of 'global.pattern' < 47
-          With your current values this DNS part is '{{ target_clustergroup }}-gitops-server-{{ pattern_name }}-{{ target_clustergroup }}' and exceeds the 63 character limit.
+          With your current values this DNS part is '{{ target_variant }}-gitops-server-{{ pattern_name }}-{{ target_variant }}' and exceeds the 63 character limit.
 
 - name: Ensure kubernetes python module is installed
   ansible.builtin.pip:


### PR DESCRIPTION
Now that the pattern-operator supports "variant" in place of
clusterGroupName we need to add support here as well.

Tested as follows:

  1. Deployment with .main.clusterGroupName set in values-global.yaml -> OK

  1. Deployment with .main.clusterGroupName and .main.variant set in values-global.yaml -> Error (expected)

  1. Deployment with .main.variant set in values-global.yaml -> OK

  1. Deployed with TARGET_CLUSTERGROUPNAME env set -> OK

  1. Deployed with TARGET_VARIANT env set (this requires a patch to pattern.sh) -> OK

  1. Deployed with both TARGET_CLUSTERGROUPNAME and TARGET_VARIANT -> Error (expected)
