### PR TITLE
Increase vault pod readiness retry count from 20 to 40

### DIFF
--- a/roles/vault_utils/tasks/vault_status.yaml
+++ b/roles/vault_utils/tasks/vault_status.yaml
@@ -10,7 +10,7 @@
     'resources' in vault_ns_rc and
     vault_ns_rc.resources is defined and
     vault_ns_rc.resources | length > 0
-  retries: 20
+  retries: 40
   delay: 45
   failed_when: >-
     vault_ns_rc is not defined or
@@ -30,7 +30,7 @@
     vault_pod_rc.resources[0].status.containerStatuses is defined and
     vault_pod_rc.resources[0].status.containerStatuses | length > 0 and
     vault_pod_rc.resources[0].status.containerStatuses[0].started | default(false)
-  retries: 20
+  retries: 40
   delay: 45
   failed_when: >-
     vault_pod_rc is not defined or


### PR DESCRIPTION
## Summary

- Doubles the retry count from 20 to 40 for the vault namespace check and vault pod readiness check in `roles/vault_utils/tasks/vault_status.yaml`
- Extends the maximum wait time from ~15 minutes to ~30 minutes per check (retries x 45s delay)
- Addresses an 18.9% failure rate on RHDP sandbox environments where shared infrastructure causes vault pod startup to exceed the current 15-minute timeout

## Context

On Red Hat Demo Platform sandbox environments, vault pod startup frequently takes longer than 15 minutes due to:
- ArgoCD deployment sequencing delays
- PVC provisioning on shared storage
- Operator unseal job timing

The delay interval (45 seconds) is unchanged -- only the retry count increases.

## Test plan

- [ ] Deploy a validated pattern on a sandbox environment and confirm vault readiness checks succeed within the extended window
- [ ] Verify no regression on environments where vault starts quickly (the check still exits as soon as the pod is ready)