### PR TITLE
Format secrets nicely when stdout callback is null

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -30,5 +30,10 @@ jobs:
       - name: Install Ansible Galaxy collection dependencies
         run: ansible-galaxy collection install -r requirements.yml
 
+      # Collection modules are referenced by short name inside this collection.
+      # ansible-lint syntax-check does not always get collection context, so point
+      # ANSIBLE_LIBRARY at plugins/modules (same as Ansible local library lookup).
       - name: Run ansible-lint
+        env:
+          ANSIBLE_LIBRARY: ${{ github.workspace }}/plugins/modules
         run: ansible-lint roles playbooks plugins

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ super-linter: ## Runs super linter locally
 .PHONY: ansible-lint
 ansible-lint: ## run ansible lint on ansible/ folder
 	podman run -it -v $(PWD):/workspace:rw,z --workdir /workspace \
+		-e ANSIBLE_LIBRARY=/workspace/plugins/modules \
 		--entrypoint "/usr/local/bin/ansible-lint" quay.io/ansible/creator-ee:latest  "-vvv" "roles" "plugins" "playbooks"
 
 .PHONY: ansible-sanitytest

--- a/playbooks/display_secrets_info.yml
+++ b/playbooks/display_secrets_info.yml
@@ -71,6 +71,35 @@
             kubernetes_secret_objects: "{{ secrets_results_late.kubernetes_secret_objects | default([]) }}"
             unique_vault_prefixes: "{{ secrets_results_late.unique_vault_prefixes | default([]) }}"
 
-    - name: Display secrets data (early and late phases)
+    - name: Resolve stdout callback for secrets display
+      ansible.builtin.set_fact:
+        _vp_stdout_callback: "{{ lookup('config', 'DEFAULT_STDOUT_CALLBACK') | default('default', true) }}"
+        _vp_default_result_format: >-
+          {{ lookup('config', 'result_format', plugin_type='callback', plugin_name='default')
+             | default('json', true) }}
+
+    - name: Display secrets data as pretty JSON text
+      ansible.builtin.debug:
+        msg: "{{ secrets_display_by_phase | to_nice_json }}"
+      when: >-
+        _vp_stdout_callback in ['community.general.yaml', 'yaml']
+        or (
+          _vp_stdout_callback in ['default', 'ansible.builtin.default']
+          and _vp_default_result_format == 'yaml'
+        )
+        or _vp_stdout_callback not in [
+          'community.general.null', 'minimal', 'community.general.dense',
+          'community.general.yaml', 'yaml',
+          'default', 'ansible.builtin.default',
+          'ansible.posix.json', 'ansible.posix.jsonl'
+        ]
+
+    - name: Display secrets data as JSON structure
       ansible.builtin.debug:
         var: secrets_display_by_phase
+      when: >-
+        _vp_stdout_callback in ['ansible.posix.json', 'ansible.posix.jsonl']
+        or (
+          _vp_stdout_callback in ['default', 'ansible.builtin.default']
+          and _vp_default_result_format == 'json'
+        )


### PR DESCRIPTION
With the current code, secrets will not be displayed at all when stdout callback is null.

This way, secrets will be formatted nicely as JSON and will show up both with the default stdout callback and when it is null.